### PR TITLE
Remove badges + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 An Minecraft integration for GOG Galaxy 2.0. Installable via GOG Galaxy (see GIF below).
 
-[![1.0.1](https://img.shields.io/badge/version-1.0.1-blue)](https://GitHub.com/urwrstkn8mare/galaxy-riot-integration/releases/)
-[![MIT License](https://img.shields.io/github/license/TouwaStar/Galaxy_Plugin_Minecraft)](https://github.com/urwrstkn8mare/TouwaStar/Galaxy_Plugin_Minecraft/fog_release/LICENSE)
-[![1.0.1 Downloads](https://img.shields.io/github/downloads/FriendsOfGalaxy/galaxy-integration-minecraft/1.0.1/total.svg)](https://github.com/FriendsOfGalaxy/galaxy-integration-minecraft/releases)
-
 ![example](example.gif)
 
 ## FAQ

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -222,8 +222,6 @@ class MinecraftPlugin(Plugin):
         time = tracked_time.time_played + multimc_time.time_played
         lastPlayed = misc.compare(tracked_time.last_played_time, multimc_time.last_played_time)
         log.debug(f"Got game time: {time}")
-        if time == 0 or lastPlayed is None:
-            return GameTime(game_id, None, None)
         return GameTime(game_id, time, lastPlayed)
 
     def handshake_complete(self):

--- a/src/utils/time_tracker.py
+++ b/src/utils/time_tracker.py
@@ -6,7 +6,4 @@ class TimeTracker(OGTimeTracker):
         return [game_id for game_id in self._running_games_dict]
 
 
-from galaxyutils.time_tracker import (  # noqa: ignore F401
-    GameNotTrackedException,
-    GamesStillBeingTrackedException,
-)
+from galaxyutils.time_tracker import GameNotTrackedException  # noqa: ignore F401


### PR DESCRIPTION
May be annoying to maintain (you would have to update version no. in the badge when you update `version.py` and `manifest.json`) and unnecessary (you can see the license and the latest version in the sidebar in Github). 

I just added it cause I came across it and thought it was cool but I think its probably redundant. 

Only keep it if you want to show downloads and want a version number in the README to reference to see what version the README and the whole repo is for when going back commits. You would have to update the version numbers in the badge URLs at the same time when you update `version.py` and `manifest.json`.

Edit: see https://github.com/FriendsOfGalaxy/galaxy-integration-minecraft/pull/8#discussion_r490078157 for reason behind extra commits ([`fca578e`](https://github.com/TouwaStar/Galaxy_Plugin_Minecraft/pull/11/commits/fca578e109abdd76e3d670e12f76374ac17ae171), [`f9da599`](https://github.com/TouwaStar/Galaxy_Plugin_Minecraft/pull/11/commits/f9da5994fce5b0ba3ca27d7584b8ca387b786e1b)).